### PR TITLE
remove deprecatet stable chart, small fixes for wordpress

### DIFF
--- a/content/en/docs/01.0/_index.md
+++ b/content/en/docs/01.0/_index.md
@@ -209,10 +209,6 @@ The output is similar to this:
 version.BuildInfo{Version:"v3.4.1", GitCommit:"c4e74854886b2efe3321e185578e6db9be0a6e29", GitTreeState:"clean", GoVersion:"go1.14.11"}
 ```
 
-From here you should be able to run the client and [add the stable repo](https://helm.sh/docs/intro/quickstart/#initialize-a-helm-chart-repository):
-
-```bash
-helm repo add stable https://charts.helm.sh/stable
-```
+From here you should be able to run the client.
 
 {{< /onlyWhen >}}

--- a/content/en/docs/03.0/_index.md
+++ b/content/en/docs/03.0/_index.md
@@ -88,7 +88,7 @@ ingress:
 mariadb:
   db:
     password: mysuperpassword123
-  master:
+  primary:
     persistence:
       size: 1Gi
 ```
@@ -143,7 +143,7 @@ mariadb:
     repository: puzzle/helm-techlab/mariadb
   db:
     password: mysuperpassword123
-  master:
+  primary:
     persistence:
       size: 1Gi
 ```
@@ -262,7 +262,7 @@ USER-SUPPLIED VALUES:
 mariadb:
   db:
     password: mysuperpassword123
-  master:
+  primary:
     persistence:
       size: 1Gi
 persistence:

--- a/content/en/docs/04.0/database.md
+++ b/content/en/docs/04.0/database.md
@@ -224,7 +224,7 @@ data:
 
 Notice the `| b64enc`, which is a builtin function to encode strings with base64.
 
-The service for our MySQL database should look like this:
+The service `templates/mysql-service.yaml` for our MySQL database should look like this:
 
 ```yaml
 apiVersion: v1

--- a/content/en/docs/04.0/deploy.md
+++ b/content/en/docs/04.0/deploy.md
@@ -25,7 +25,7 @@ The `docker-registry.mobicorp.ch/puzzle/k8s/kurs/example-spring-boot:latest` app
 
 ### Solution
 
-In our `values.yaml` we only have to change the value of `image.repository`:
+In our `values.yaml` we only have to change the value of `image.repository` and `image.tag`:
 
 {{< onlyWhenNot mobi >}}
 
@@ -38,9 +38,9 @@ replicaCount: 1
 
 image:
   repository: appuio/example-spring-boot
-  tag: latest
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
+  tag: latest
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
* Remove deprecated helm stable chart. We don't need this anyway. https://github.com/helm/charts/blob/master/README.md#status-of-the-project #20 
* Change values for Wordpress chart as `master` was renamed to `primary` in mariadb dependency.
* Small changes to clarify some steps.
