### PR TITLE
Improve usage of onlyWhen/onlyWhenNot shortcodes

### DIFF
--- a/content/en/docs/01.0/_index.md
+++ b/content/en/docs/01.0/_index.md
@@ -30,7 +30,7 @@ The output should be similar to this:
 version.BuildInfo{Version:"v3.4.1", GitCommit:"c4e74854886b2efe3321e185578e6db9be0a6e29", GitTreeState:"clean", GoVersion:"go1.14.11"}
 ```
 
-{{< onlyWhen mobi >}}
+{{% onlyWhen mobi %}}
 
 
 ## Task 2
@@ -47,6 +47,6 @@ If you have direct access to the internet from your location, the proxy configur
 {{% /alert %}}
 
 Replace `<username`> and `<password>` with your credentials. If you have special characters in your password, escape them with their corresponding hexadecimal values according to [this article](https://en.wikipedia.org/wiki/Percent-encoding#Percent-encoding_reserved_characters).
-{{< /onlyWhen >}}
+{{% /onlyWhen %}}
 
 You are now all set to start with the labs!

--- a/content/en/docs/02.0/_index.md
+++ b/content/en/docs/02.0/_index.md
@@ -16,7 +16,7 @@ helm create mychart
 
 You now find a `mychart` directory with the newly created chart. It already is a valid and fully functional chart which deploys a nginx instance. Have a look at the generated files and their content. For an explanation of the files, visit the [Helm Developer Documentation](https://docs.helm.sh/developing_charts/#the-chart-file-structure). In a later section you'll find all the information about Helm templates.
 
-{{< onlyWhen mobi >}}
+{{% onlyWhen mobi %}}
 Because you cannot pull the `nginx` container image on your cluster, you have to use the `docker-registry.mobicorp.ch/puzzle/k8s/kurs/nginx` container image. Change your `values.yaml` to match the following:
 
 ```yaml
@@ -28,7 +28,7 @@ image:
 [...]
 ```
 
-{{< /onlyWhen >}}
+{{% /onlyWhen %}}
 
 
 ## Task 2
@@ -222,9 +222,9 @@ nginx is now available at the given port number indicated by the `NodePort` and 
 Use either the output of the `helm upgrade` command, or `kubectl get node -o wide` to get a node ip address. Remember, [NodePort's](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport) are open on any kubernetes node
 {{% /alert %}}
 
-{{< onlyWhen mobi >}}
+{{% onlyWhen mobi %}}
 In case you do not have permissions to list the nodes with `kubectl get node` simply use `kubedev-worker-00bb7020c0eb.phoenix.mobicorp.test` as the node address to access the welcome page.
-{{< /onlyWhen >}}
+{{% /onlyWhen %}}
 
 
 ## Task 5

--- a/content/en/docs/03.0/_index.md
+++ b/content/en/docs/03.0/_index.md
@@ -15,7 +15,7 @@ Check out [Artifact Hub](https://artifacthub.io/) where you'll find a huge numbe
 
 As this WordPress Helm chart is published in Bitnami's Helm repository, we're first going to add it to our local repo list:
 
-{{< onlyWhen mobi >}}
+{{% onlyWhen mobi %}}
 You have to set your `HTTP_PROXY` environment variable in order to access the Bitnami Helm repository:
 
 ```bash
@@ -42,7 +42,7 @@ Replace `u...:PASSWORD` with your account details. If you have specials chars in
 If you have direct access to the internet from your location, the proxy configuration is not required.
 {{% /alert %}}
 
-{{< /onlyWhen >}}
+{{% /onlyWhen %}}
 
 ```bash
 helm repo add bitnami https://charts.bitnami.com/bitnami
@@ -90,7 +90,7 @@ Make sure to set the proper value as hostname. `<appdomain>` will be provided by
 
 If you look inside the [Chart.yaml](https://github.com/bitnami/charts/blob/master/bitnami/wordpress/Chart.yaml) file of the WordPress chart you see a dependency to the [MariaDB Helm chart](https://github.com/bitnami/charts/tree/master/bitnami/mariadb). All the MariaDB values are used by this dependent Helm chart and the chart is automatically deployed when installing WordPress.
 
-{{< onlyWhen mobi >}}
+{{% onlyWhen mobi %}}
 The WordPress and MariaDB charts use (at the time of writing) the following container images:
 
 * `docker.io/bitnami/wordpress:5.4.0-debian-10-r6`
@@ -149,7 +149,7 @@ ingress:
 [...]
 ```
 
-{{< /onlyWhen >}}
+{{% /onlyWhen %}}
 
 The `Chart.yaml` file allows us to define dependencies on other charts. In our Wordpress chart we use the `Chart.yaml` to add a `mariadb` to store the WordPress data in.
 

--- a/content/en/docs/04.0/database.md
+++ b/content/en/docs/04.0/database.md
@@ -47,7 +47,7 @@ We want to add a MariaDB database and use it as a backend for our `example-web-p
 You can use the existing templates (`deployment.yaml`, `service.yaml`) as starting point to create the new templates.
 {{% /alert %}}
 
-{{< onlyWhenNot mobi  >}}
+{{% onlyWhenNot mobi %}}
 
 ```yaml
 ---
@@ -112,8 +112,9 @@ spec:
         emptyDir: {}
 ```
 
-{{< /onlyWhenNot >}}
-{{< onlyWhen mobi  >}}
+{{% /onlyWhenNot %}}
+
+{{% onlyWhen mobi %}}
 You have to use `docker-registry.mobicorp.ch/puzzle/k8s/kurs/mariadb:10.5` as the container image.
 
 ```yaml
@@ -180,7 +181,7 @@ spec:
         emptyDir: {}
 ```
 
-{{< /onlyWhen >}}
+{{% /onlyWhen %}}
 
 You also have to create a template for the secret:
 
@@ -382,7 +383,7 @@ spec:
 ```
 
 And then in our `values.yaml` we need to add:
-{{< onlyWhenNot mobi  >}}
+{{% onlyWhenNot mobi %}}
 
 ```yaml
 database:
@@ -403,8 +404,9 @@ database:
   affinity: {}
 ```
 
-{{< /onlyWhenNot >}}
-{{< onlyWhen mobi  >}}
+{{% /onlyWhenNot %}}
+
+{{% onlyWhen mobi %}}
 
 ```yaml
 database:
@@ -425,7 +427,7 @@ database:
   affinity: {}
 ```
 
-{{< /onlyWhen >}}
+{{% /onlyWhen %}}
 
 Finally, to upgrade the existing release run:
 

--- a/content/en/docs/04.0/deploy.md
+++ b/content/en/docs/04.0/deploy.md
@@ -8,26 +8,26 @@ Using the generated and modified Helm chart, we are going to deploy our own awes
 
 ## Task 1: Adapt the chart
 
-{{< onlyWhenNot mobi >}}
+{{% onlyWhenNot mobi %}}
 Our container image has the name `quay.io/acend/example-web-python:latest` and is a very basic python application. Change the content of your `deployment.yml` and `values.yml` so a pod with the `example-web-python` image is started instead of the `nginx` image from the default chart we created with `helm create mychart` in lab 2.
 
 The `quay.io/acend/example-web-python:latest` application is running on port `8080`. Change the existing `deployment.yaml` accordingly.
-{{< /onlyWhenNot >}}
+{{% /onlyWhenNot %}}
 
 After the changes, create or upgrade a release from your template.
 
-{{< onlyWhen mobi >}}
+{{% onlyWhen mobi %}}
 Our container image has the name `docker-registry.mobicorp.ch/puzzle/k8s/kurs/example-web-python:latest` and is a very basic python application. Change the content of your `deployment.yml` and `values.yml` so a pod with the `example-web-python` image is started instead of the `nginx` image from the default chart we created with `helm create mychart` in lab 2.
 
 The `docker-registry.mobicorp.ch/puzzle/k8s/kurs/example-web-python:latest` application is running on port `8080`. Change the existing `deployment.yaml` accordingly.
-{{< /onlyWhen >}}
+{{% /onlyWhen %}}
 
 
 ### Solution
 
 In our `values.yaml` we only have to change the value of `image.repository` and `image.tag`:
 
-{{< onlyWhenNot mobi >}}
+{{% onlyWhenNot mobi %}}
 
 ```yaml
 # Default values for mychart.
@@ -111,8 +111,8 @@ tolerations: []
 affinity: {}
 ```
 
-{{< /onlyWhenNot >}}
-{{< onlyWhen mobi >}}
+{{% /onlyWhenNot %}}
+{{% onlyWhen mobi %}}
 
 ```yaml
 # Default values for mychart.
@@ -196,7 +196,7 @@ tolerations: []
 affinity: {}
 ```
 
-{{< /onlyWhen >}}
+{{% /onlyWhen %}}
 
 And then our `deployment.yaml` should look as follows. Note the changed `.spec.containers[0].ports[0].containerPort`:
 
@@ -285,9 +285,9 @@ The template folder already has a file for an ingress resource. There are even s
 The current values for the ingress depends on the Kubernetes cluster. Ask your instructor for the correct values if you are not sure.
 {{% /alert %}}
 
-{{< onlyWhen mobi >}}
+{{% onlyWhen mobi %}}
 You can use `helmtechlab-python-<namespace>.phoenix.mobicorp.test` as your hostname if you want to access your deployed application. It might take some time until your ingress hostname is accessable as the DNS name first has to be propagated correctly.
-{{< /onlyWhen >}}
+{{% /onlyWhen %}}
 
 
 ### Solution Task 2

--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -48,9 +48,9 @@ With these concepts in mind, we can now explain Helm like this:
 
 ### Task: Training Setup
 
-{{< onlyWhenNot mobi >}}
+{{% onlyWhenNot mobi %}}
 
-{{< onlyWhen rancher >}}
+{{% onlyWhen rancher %}}
 
 
 #### Login to the Lab Cluster
@@ -99,7 +99,7 @@ The `PATH` can be set in Windows in the advanced system settings. It depends on 
 {{% /alert %}}
 
 
-{{< /onlyWhen >}}
+{{% /onlyWhen %}}
 
 
 #### Create Namespace
@@ -112,21 +112,21 @@ You can create your namespace with:
 kubectl create namespace <namespace>
 ```
 
-{{< onlyWhen rancher >}}
+{{% onlyWhen rancher %}}
 {{% alert title="Note" color="primary" %}}
 Namespaces created via `kubectl` have to be assigned to the correct Rancher Project in order to be visible in the Rancher web console. Please ask your teacher for this assignment. Or you can create the Namespace directly within the Rancher web console.
 {{% /alert %}}
-{{< /onlyWhen >}}
+{{% /onlyWhen %}}
 
-{{< /onlyWhenNot >}}
+{{% /onlyWhenNot %}}
 
-{{< onlyWhen mobi >}}
+{{% onlyWhen mobi %}}
 Make sure you have access to the Mobiliar `dev` Kubernetes cluster and `kubectl` is configured to use the right context.
 
 We already created a namespace for you. The name of your namespace is equal to your Mobi U-Account `u....` and has been placed in the Project `helm`.
 Just to see it again, a namespace in Kubernetes can be created with:
 
-{{< /onlyWhen >}}
+{{% /onlyWhen %}}
 
 In the labs we are going to use `<namespace>` as a placeholder for your namespace.
 


### PR DESCRIPTION
* Comes with updated submodule themes/docsy-plus
* Use {{% ... %}} instead of {{< ... >}} in Markdown files, see https://gohugo.io/content-management/shortcodes/#shortcodes-with-markdown